### PR TITLE
Pass in redirect_slashes

### DIFF
--- a/fastapi/applications.py
+++ b/fastapi/applications.py
@@ -57,6 +57,7 @@ class FastAPI(Starlette):
         dependencies: Optional[Sequence[Depends]] = None,
         default_response_class: Type[Response] = Default(JSONResponse),
         docs_url: Optional[str] = "/docs",
+        redirect_slashes: Optional[bool] = True,
         redoc_url: Optional[str] = "/redoc",
         swagger_ui_oauth2_redirect_url: Optional[str] = "/docs/oauth2-redirect",
         swagger_ui_init_oauth: Optional[Dict[str, Any]] = None,
@@ -130,6 +131,7 @@ class FastAPI(Starlette):
             include_in_schema=include_in_schema,
             responses=responses,
             generate_unique_id_function=generate_unique_id_function,
+            redirect_slashes=redirect_slashes,
         )
         self.exception_handlers: Dict[
             Any, Callable[[Request, Any], Union[Response, Awaitable[Response]]]


### PR DESCRIPTION
Currently, `redirect_slashes` option is available from Starlette but doesn't work in FastAPI.